### PR TITLE
PUB-1993 - Fix issue with incorrect end date + remove

### DIFF
--- a/client_secrets.ps1
+++ b/client_secrets.ps1
@@ -175,7 +175,7 @@ try {
             Write-Output "Expiry Date Range is $expiringRangeDate. It has $($expiringRangeDateObj.Days) day"
             if ($endDateObj.Days -lt 1) {
               Write-Output "$keyName has expired ($endDate). Removing Key"
-              Remove-AzADAppCredential -ObjectId $appId -KeyId $keyId -Confirm:$false -DefaultProfile $targetContext
+              Remove-AzADAppCredential -ObjectId $objectId -KeyId $keyId -DefaultProfile $targetContext
             }
             elseif ($expiringRangeDateObj.Days -lt $expiringRangeDays) {
               Write-Output "$keyName will expire within $expiringRangeDays."           

--- a/client_secrets.ps1
+++ b/client_secrets.ps1
@@ -163,7 +163,8 @@ try {
             $keyId = $s.KeyId
             Write-Output "$appName Secret $keyName"
   
-            $endDate = Get-Date($s.EndDate) 
+            $endDate = Get-Date($s.EndDate)
+
             $currentDate = Get-Date
             $expiringRangeDate = $(Get-Date).AddDays($expiringRangeDays)
 

--- a/client_secrets.ps1
+++ b/client_secrets.ps1
@@ -163,7 +163,7 @@ try {
             $keyId = $s.KeyId
             Write-Output "$appName Secret $keyName"
   
-            $endDate = Get-Date($s.EndDate)
+            $endDate = Get-Date($s.EndDateTime)
 
             $currentDate = Get-Date
             $expiringRangeDate = $(Get-Date).AddDays($expiringRangeDays)


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1993

### Change description ###

This runbook is used in PIP Shared infrastructure to refresh the app secrets. The job has been failing for quite a while due to an invalid date error.

After further investigation, this is due to 'EndDate' not existing on the response from https://learn.microsoft.com/en-us/powershell/module/az.resources/get-azadappcredential?view=azps-9.7.0

Instead, it is 'EndDateTime'.

During this investigation, it was also found the remove secret was not working due to passing in the app ID rather than the object ID. This has also been changed to object ID (and an unneeded -confirm flag removed)

I have tried running this in the P&I Test Env against an expiring secret, which then ran successfully, generated a new secret and updated the KV.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
